### PR TITLE
handle case where select() is interrupted by a signal

### DIFF
--- a/lib/Hijk.pm
+++ b/lib/Hijk.pm
@@ -281,8 +281,8 @@ sub _build_http_message {
             } 0..$#{$args->{head}}/2
         ) : (),
         "",
-        $args->{body} ? $args->{body} : ()
-    ) . $CRLF;
+        $args->{body} ? $args->{body} : ""
+    );
 }
 
 our $SOCKET_CACHE = {};

--- a/t/build_http_message.t
+++ b/t/build_http_message.t
@@ -30,7 +30,7 @@ for my $protocol ("HTTP/1.0", "HTTP/1.1") {
         "GET / $protocol\x0d\x0a".
         "Host: www.example.com\x0d\x0a".
         "Content-Length: 7\x0d\x0a\x0d\x0a".
-        "morning\x0d\x0a";
+        "morning";
 
     is Hijk::_build_http_message({ protocol => $protocol, host => "www.example.com", head => ["X-Head" => "extra stuff"] }),
         "GET / $protocol\x0d\x0a".
@@ -49,7 +49,7 @@ for my $protocol ("HTTP/1.0", "HTTP/1.1") {
         "Content-Length: 4\x0d\x0a".
         "X-Head: extra stuff\x0d\x0a".
         "\x0d\x0a".
-        "OHAI\x0d\x0a";
+        "OHAI";
 }
 
 done_testing;

--- a/t/select-timeout.t
+++ b/t/select-timeout.t
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+use Hijk;
+use Time::HiRes;
+
+my $parent_pid = $$;
+pipe(my $rh, my $wh) or die "Failed to create pipe: $!";
+
+my $pid = fork;
+die "Fail to fork then start a plack server" unless defined $pid;
+
+if ($pid == 0) {
+    Time::HiRes::sleep(0.5);
+    for (1..10) {
+        kill('HUP', $parent_pid);
+        Time::HiRes::sleep(0.1);
+    }
+    exit;
+}
+
+$SIG{HUP} = sub { warn "SIGHUP received\n" };
+
+my $timeout = 2;
+vec(my $rin = '', fileno($rh), 2) = 1;
+
+my $start = Time::HiRes::time;
+Hijk::_select($rin, undef, undef, $timeout);
+my $elapsed = Time::HiRes::time - $start;
+
+ok(
+    $elapsed >= $timeout,
+    sprintf("handle signal during select, took=%.2fs, expected at least=%.2fs", $elapsed, $timeout)
+);
+
+done_testing;


### PR DESCRIPTION
I propose this fix for the case where select() syscall is interrupted by a signal.
The PR consist of two commits: first demonstrates the issue, second fixes it.