### PR TITLE
fix remove trailing CRLF (after body)

### DIFF
--- a/lib/Hijk.pm
+++ b/lib/Hijk.pm
@@ -280,8 +280,8 @@ sub _build_http_message {
             } 0..$#{$args->{head}}/2
         ) : (),
         "",
-        $args->{body} ? $args->{body} : ()
-    ) . $CRLF;
+        $args->{body} ? $args->{body} : ""
+    );
 }
 
 our $SOCKET_CACHE = {};

--- a/t/build_http_message.t
+++ b/t/build_http_message.t
@@ -30,7 +30,7 @@ for my $protocol ("HTTP/1.0", "HTTP/1.1") {
         "GET / $protocol\x0d\x0a".
         "Host: www.example.com\x0d\x0a".
         "Content-Length: 7\x0d\x0a\x0d\x0a".
-        "morning\x0d\x0a";
+        "morning";
 
     is Hijk::_build_http_message({ protocol => $protocol, host => "www.example.com", head => ["X-Head" => "extra stuff"] }),
         "GET / $protocol\x0d\x0a".
@@ -49,7 +49,7 @@ for my $protocol ("HTTP/1.0", "HTTP/1.1") {
         "Content-Length: 4\x0d\x0a".
         "X-Head: extra stuff\x0d\x0a".
         "\x0d\x0a".
-        "OHAI\x0d\x0a";
+        "OHAI";
 }
 
 done_testing;


### PR DESCRIPTION
1. Problem

Hijk adds CRLF after body content.
With this request:

    my $res = Hijk::request({
       method  => "GET",
       host    => "localhost",
       port    => "81",
       body    => "body",
       timeout => 1,
    });

Hijk does

    $ nc -l -p 81 | hexdump -C
    00000000  47 45 54 20 2f 20 48 54  54 50 2f 31 2e 31 0d 0a  |GET / HTTP/1.1..|
    00000010  48 6f 73 74 3a 20 6c 6f  63 61 6c 68 6f 73 74 0d  |Host: localhost.|
    00000020  0a 43 6f 6e 74 65 6e 74  2d 4c 65 6e 67 74 68 3a  |.Content-Length:|
    00000030  20 34 0d 0a 0d 0a 62 6f  64 79 0d 0a              | 4....body..|
    0000003c                                 ^
                                             ^
this is wrong --------------------------------

2. How it should be

See what curl does:

    $ curl --max-time 1 --data body http://localhost:81
    $ nc -l -p 81 | hexdump -C
    00000000  50 4f 53 54 20 2f 20 48  54 54 50 2f 31 2e 31 0d  |POST / HTTP/1.1.|
    00000010  0a 55 73 65 72 2d 41 67  65 6e 74 3a 20 63 75 72  |.User-Agent: cur|
    00000020  6c 2f 37 2e 33 37 2e 30  0d 0a 48 6f 73 74 3a 20  |l/7.37.0..Host: |
    00000030  6c 6f 63 61 6c 68 6f 73  74 3a 38 31 0d 0a 41 63  |localhost:81..Ac|
    00000040  63 65 70 74 3a 20 2a 2f  2a 0d 0a 43 6f 6e 74 65  |cept: */*..Conte|
    00000050  6e 74 2d 4c 65 6e 67 74  68 3a 20 34 0d 0a 43 6f  |nt-Length: 4..Co|
    00000060  6e 74 65 6e 74 2d 54 79  70 65 3a 20 61 70 70 6c  |ntent-Type: appl|
    00000070  69 63 61 74 69 6f 6e 2f  78 2d 77 77 77 2d 66 6f  |ication/x-www-fo|
    00000080  72 6d 2d 75 72 6c 65 6e  63 6f 64 65 64 0d 0a 0d  |rm-urlencoded...|
    00000090  0a 62 6f 64 79                                    |.body|

and wget:

    $ wget http://localhost:81 --post-data=body -O- --timeout=1
    $ nc -l -p 81 | hexdump -C
    00000000  50 4f 53 54 20 2f 20 48  54 54 50 2f 31 2e 31 0d  |POST / HTTP/1.1.|
    00000010  0a 55 73 65 72 2d 41 67  65 6e 74 3a 20 57 67 65  |.User-Agent: Wge|
    00000020  74 2f 31 2e 31 35 20 28  6c 69 6e 75 78 2d 67 6e  |t/1.15 (linux-gn|
    00000030  75 29 0d 0a 41 63 63 65  70 74 3a 20 2a 2f 2a 0d  |u)..Accept: */*.|
    00000040  0a 48 6f 73 74 3a 20 6c  6f 63 61 6c 68 6f 73 74  |.Host: localhost|
    00000050  3a 38 31 0d 0a 43 6f 6e  6e 65 63 74 69 6f 6e 3a  |:81..Connection:|
    00000060  20 4b 65 65 70 2d 41 6c  69 76 65 0d 0a 43 6f 6e  | Keep-Alive..Con|
    00000070  74 65 6e 74 2d 54 79 70  65 3a 20 61 70 70 6c 69  |tent-Type: appli|
    00000080  63 61 74 69 6f 6e 2f 78  2d 77 77 77 2d 66 6f 72  |cation/x-www-for|
    00000090  6d 2d 75 72 6c 65 6e 63  6f 64 65 64 0d 0a 43 6f  |m-urlencoded..Co|
    000000a0  6e 74 65 6e 74 2d 4c 65  6e 67 74 68 3a 20 34 0d  |ntent-Length: 4.|
    000000b0  0a 0d 0a 62 6f 64 79                              |...body|

RFC says:
http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html

        Request       = Request-Line              ; Section 5.1
                        *(( general-header        ; Section 4.5
                         | request-header         ; Section 5.3
                         | entity-header ) CRLF)  ; Section 7.1
                        CRLF
                        [ message-body ]          ; Section 4.3

no CRLF after message body

3. How I noticed this???

Using my YAHC project (where I copy-pasted _build_http_message function) I
noticed that nginx logs bogus 400 response right after normal 200 request.
Apparently those 2 trailing bytes were recongnized as new request.