### PR TITLE
Allow overriding Host header in head arrayref

### DIFF
--- a/lib/Hijk.pm
+++ b/lib/Hijk.pm
@@ -278,7 +278,7 @@ sub _build_http_message {
     return join(
         $CRLF,
         ($args->{method} || "GET")." $path_and_qs " . ($args->{protocol} || "HTTP/1.1"),
-        "Host: $args->{host}",
+        ((grep { lc($_) eq 'host' } @{ $args->{head} || [] }) ? () : "Host: $args->{host}"),
         defined($args->{body}) ? ("Content-Length: " . length($args->{body})) : (),
         $args->{head} ? (
             map {

--- a/t/build_http_message.t
+++ b/t/build_http_message.t
@@ -86,6 +86,11 @@ for my $protocol ("HTTP/1.0", "HTTP/1.1") {
         "X-Head: extra stuff${CRLF}".
         "${CRLF}".
         "OHAI";
+
+    # Allow overriding Host header in head arrayref
+    is Hijk::_build_http_message({ protocol => $protocol, host => "localhost", head => [ "Host" => "www.example.com" ] }),
+        "GET / $protocol${CRLF}".
+        "Host: www.example.com${CRLF}${CRLF}";
 }
 
 done_testing;


### PR DESCRIPTION
Hey Gugod,

Over at Nestoria we do some nasty things relying on the Host header and being able to make requests like this:

    alex@kyon:~$ curl -s -H 'Host: www.nestoria.fr' http://www.nestoria.es | grep '<title>'
                <title>Recherche Immobilière par Nestoria</title>

What do you think of this pull request? Too evil to merge?

For what it's worth curl and LWP::UserAgent do allow us to do this, but HTTP::Tiny doesn't ;-)

> The Host header is generated from the URL in accordance with RFC 2616. It is a fatal error to specify Host in the headers option. Other headers may be ignored or overwritten if necessary for transport compliance.
> -- https://metacpan.org/pod/HTTP::Tiny

Thanks,

Alex